### PR TITLE
Ignore the tests folder 

### DIFF
--- a/.RBuildignore
+++ b/.RBuildignore
@@ -6,3 +6,4 @@
 ^cran-comments\.md$
 ^\.travis\.yml$
 ^CRAN-RELEASE$
+^tests$


### PR DESCRIPTION
Hi @felixthoemmes 

Regarding the problem:
> checking for unstated dependencies in 'tests' ... WARNING
>   '::' or ':::' import not declared from: 'rdd'
> 

it is still caused by the tests. In my previous update, I only prevented  tests from running. However, but it seems like the building process still checks the codes in the 'tests' folder. 

I added a line about the 'tests' folder to the `.Rbuildignore` file. Hopefully this would fix the problem.

Wang



